### PR TITLE
Suggest alternative web3 Browser to download

### DIFF
--- a/App.css
+++ b/App.css
@@ -1,0 +1,5 @@
+.download img {
+    margin-top: 10px;
+    width: 220px;
+    display: block;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="App.css">
   <title>Livepeer Token Miner</title>
   <style>
     html {
@@ -20,8 +20,19 @@
 <body>
   <!-- <div class="progress"></div> -->
   <div id="root">
-    Web3 is not enabled in your browser. Please download an extension such as
-    <a href="https://metamask.io/">MetaMask</a>.
+    <center>
+        Web3 is not enabled in your browser. Please download an extension such as
+        <a href="https://metamask.io/">MetaMask</a> or <a href="https://trustwalletapp.com">Trust</a> for mobile.
+
+        <div class="download">
+          <a href="https://metamask.io">
+            <img src="https://raw.githubusercontent.com/MetaMask/faq/master/images/download-metamask-dark.png">
+          </a>
+          <a href="https://trustwalletapp.com">
+            <img src="https://uploads-ssl.webflow.com/5a88babea6e0f90001b39b0d/5aa8800f11c8585326c469c1_Download_blue-p-1080.png"></img>
+          </a>
+        </div>
+    </center>
   </div>
   <script src="./index.js"></script>
 </body>


### PR DESCRIPTION
One of the best practices to allow anyone to quickly download the web3 browser. Here is how we did it with a game:

![screen shot 2018-04-10 at 5 45 05 pm](https://user-images.githubusercontent.com/1641795/39493559-2517ce16-4d48-11e8-8d67-b1f7d481cbba.png)

This is how it looks for minecraft:

<img width="784" alt="screen shot 2018-05-01 at 2 00 25 pm" src="https://user-images.githubusercontent.com/1641795/39493579-3cec309a-4d48-11e8-820d-6e24b71a3319.png">

Also if you are curious about Trust Wallet, it is open source: https://github.com/TrustWallet/trust-wallet-ios